### PR TITLE
WorldPay Validation

### DIFF
--- a/connectorconfig/worldpay.go
+++ b/connectorconfig/worldpay.go
@@ -19,10 +19,10 @@ const (
 )
 
 type WorldpayCredentials struct {
-	Username              *string             `json:"username" yaml:"username" validate:"required,gt=0"`
-	Password              *string             `json:"password" yaml:"password" validate:"required,gt=0"`
-	MerchantID            string              `json:"merchantID" yaml:"merchantID" validate:"required"`
-	ReportGroup           string              `json:"reportGroup" yaml:"reportGroup" validate:"-"`
+	Username              *string             `json:"username" yaml:"username" validate:"required,gt=0,lte=20"`
+	Password              *string             `json:"password" yaml:"password" validate:"required,gt=0,lte=20"`
+	MerchantID            string              `json:"merchantID" yaml:"merchantID" validate:"gte=1,lte=50"`
+	ReportGroup           string              `json:"reportGroup" yaml:"reportGroup" validate:"gte=1,lte=25"`
 	Environment           WorldpayEnvironment `json:"environment" yaml:"environment" validate:"oneof=sandbox postlive transactpostlive production productiontransact prelive transactprelive"`
 	CardinalApiIdentifier *string             `json:"cardinalApiIdentifier" yaml:"cardinalApiIdentifier" validate:"required"`
 	CardinalApiKey        *string             `json:"cardinalApiKey" yaml:"cardinalApiKey" validate:"required"`

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,13 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-playground/assert/v2 v2.0.1 h1:MsBgLAaY856+nPRTKrp3/OZK38U/wa0CcBYNjji3q3A=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
+github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
+github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD876Lmtgy7VtROAbHHXk8no=
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
+github.com/go-playground/validator/v10 v10.2.0 h1:KgJ0snyC2R9VXYN2rneOtQcw5aHQB1Vv0sFl1UcHBOY=
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
+github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/utils/generate.go
+++ b/utils/generate.go
@@ -222,7 +222,7 @@ func buildSpec(conf Template) (object.Specification, error) {
 			Username:              &chg,
 			Password:              &chg,
 			MerchantID:            chg,
-			ReportGroup:           "",
+			ReportGroup:           chg,
 			Environment:           "sandbox",
 			CardinalApiIdentifier: &chg,
 			CardinalApiKey:        &chg,

--- a/utils/validate_test.go
+++ b/utils/validate_test.go
@@ -19,14 +19,14 @@ func TestAdditionalUnknownFields(t *testing.T) {
 
 // test for missing field
 func TestMissingFields(t *testing.T) {
-	rawJson := []byte(`{"kind":"Connector","metadata":{"name":"change-me","displayName":"","description":"","annotations":null,"labels":null,"disabled":false},"specVersion":"v1","selector":{"priority":50,"expressions":[{"key":"charge.amount.currency","operator":"Equal","conversion":"","values":["GBP"]}]},"spec":{"library":"paypal-websitepaymentspro","configuration":"eyJhcGlQYXNzd29yZCI6bnVsbCwiYXBpU2lnbmF0dXJlIjoiQ0hBTkdFLU1FIiwic3VwcG9ydGVkQ3VycmVuY2llcyI6WyJVU0QiXSwiY2FyZGluYWxQcm9jZXNzb3JJRCI6IkNIQU5HRS1NRSIsImNhcmRpbmFsTWVyY2hhbnRJRCI6IkNIQU5HRS1NRSIsImNhcmRpbmFsVHJhbnNhY3Rpb25QdyI6IkNIQU5HRS1NRSIsImNhcmRpbmFsVHJhbnNhY3Rpb25VUkwiOiJDSEFOR0UtTUUiLCJjYXJkaW5hbEFQSUlkZW50aWZpZXIiOiJDSEFOR0UtTUUiLCJjYXJkaW5hbEFQSUtleSI6IkNIQU5HRS1NRSIsImNhcmRpbmFsT3JnVW5pdElEIjoiQ0hBTkdFLU1FIiwiZW52aXJvbm1lbnQiOiJzYW5kYm94In0="}}`)
+	rawJson := []byte(`{"kind":"Connector","metadata":{"displayName":"","description":"","annotations":null,"labels":null,"disabled":false},"specVersion":"v1","selector":{"priority":50,"expressions":[{"key":"charge.amount.currency","operator":"Equal","conversion":"","values":["GBP"]}]},"spec":{"library":"paypal-websitepaymentspro","configuration":"eyJhcGlQYXNzd29yZCI6bnVsbCwiYXBpU2lnbmF0dXJlIjoiQ0hBTkdFLU1FIiwic3VwcG9ydGVkQ3VycmVuY2llcyI6WyJVU0QiXSwiY2FyZGluYWxQcm9jZXNzb3JJRCI6IkNIQU5HRS1NRSIsImNhcmRpbmFsTWVyY2hhbnRJRCI6IkNIQU5HRS1NRSIsImNhcmRpbmFsVHJhbnNhY3Rpb25QdyI6IkNIQU5HRS1NRSIsImNhcmRpbmFsVHJhbnNhY3Rpb25VUkwiOiJDSEFOR0UtTUUiLCJjYXJkaW5hbEFQSUlkZW50aWZpZXIiOiJDSEFOR0UtTUUiLCJjYXJkaW5hbEFQSUtleSI6IkNIQU5HRS1NRSIsImNhcmRpbmFsT3JnVW5pdElEIjoiQ0hBTkdFLU1FIiwiZW52aXJvbm1lbnQiOiJzYW5kYm94In0="}}`)
 	configuration.Initialise()
 	if errs := Validate(rawJson, "v1"); len(errs) > 0 {
 		_ = PrettyPrint(errs)
 		assert.Equal(t, 3, len(errs))
 		assert.Equal(t, errs["PayPalWebsitePaymentsProCredentials.APIUsername"], "APIUsername is a required field") // missing field
 		assert.Equal(t, errs["PayPalWebsitePaymentsProCredentials.APIPassword"], "APIPassword is a required field") // null field
-		assert.Equal(t, errs["Definition.MetaData.ProjectID"], "ProjectID is a required field")
+		assert.Equal(t, errs["Definition.MetaData.Name"], "Name is a required field")
 	}
 }
 


### PR DESCRIPTION
worldpay requires a reportgroup.
Set min/max field lengths for username/passwords
Updated tests to reflect changes