### PR TITLE
GooglePay Worldpay Updates and Mappings

### DIFF
--- a/connectorconfig/google.go
+++ b/connectorconfig/google.go
@@ -1,35 +1,34 @@
 package connectorconfig
 
 type GooglePay struct {
-	GooglePayPageId              string                      `json:"googlePayPageId" validate:"-"`
-	GoogleEnvironment            GoogleEnvironment           `json:"googleEnvironment" validate:"-"`     // PRODUCTION: Used to return chargeable payment methods when a valid Google merchant ID is specified and configured for the domain.TEST: Dummy payment methods that are suitable for testing (default).
-	GoogleMerchantId             string                      `json:"googleMerchantId" validate:"-"`      // A Google merchant identifier issued after your website is approved by Google. Required when PaymentsClient is initialized with an environment property of PRODUCTION. See the Integration checklist for more information about the approval process and how to obtain a Google merchant identifier.
-	GoogleMerchantName           string                      `json:"googleMerchantName" validate:"-"`    // Merchant name encoded as UTF-8. Merchant name is rendered in the payment sheet. In TEST environment, or if a merchant isn't recognized, a “Pay Unverified Merchant” message is displayed in the payment sheet.
-	GoogleApiVersion             int                         `json:"googleApiVersion" validate:"-"`      // Major API version. The value is 2 for this specification.
-	GoogleApiVersionMinor        int                         `json:"googleApiVersionMinor" validate:"-"` // Minor API version. The value is 0 for this specification.
-	GoogleExistingMethodRequired bool                        `json:"googleExistingMethodRequired"`       // If set to true then the IsReadyToPayResponse object includes an additional property that describes the visitor's readiness to pay with one or more payment methods specified in allowedPaymentMethods.
-	GoogleAcceptCard             bool                        `json:"googleAcceptCard"`                   // enable this to allow card payments through google pay
-	GoogleCardAuthMethods        []GoogleCardAuthMethod      `json:"googleCardAuthMethods"`
-	GoogleCardNetworks           []GoogleCardNetwork         `json:"googleCardNetworks"`
-	GoogleCardTokenType          GoogleCardTokenType         `json:"googleCardTokenType"`
-	GoogleCardGateway            GoogleCardGateway           `json:"googleCardGateway"`           // https://developers.google.com/pay/api/web/reference/request-objects#gateway
-	GoogleCardMerchantId         string                      `json:"googleCardMerchantId"`        // https://developers.google.com/pay/api/web/reference/request-objects#gateway
-	GoogleCardAllowPrepaid       bool                        `json:"googleCardAllowPrepaid"`      // Allow customer to pay with prepaid card
-	GoogleCardAllowCredit        bool                        `json:"googleCardAllowCredit"`       // Allow customer to pay with credit card
-	GoogleCardBillingAddressReq  GoogleCardBillingAddressReq `json:"googleCardBillingAddressReq"` // Set level of billing requirement
+	GoogleEnvironment              GoogleEnvironment           `json:"googleEnvironment"`              // (environment) PRODUCTION: Used to return chargeable payment methods when a valid Google merchant ID is specified and configured for the domain.TEST: Dummy payment methods that are suitable for testing (default).
+	GoogleMerchantId               string                      `json:"googleMerchantId"`               // (merchantInfo.merchantId) A Google merchant identifier issued after your website is approved by Google. Required when PaymentsClient is initialized with an environment property of PRODUCTION. See the Integration checklist for more information about the approval process and how to obtain a Google merchant identifier. (https://developers.google.com/pay/api/web/reference/request-objects#MerchantInfo)
+	GoogleMerchantName             string                      `json:"googleMerchantName"`             // (merchantInfo.merchantName) Merchant name encoded as UTF-8. Merchant name is rendered in the payment sheet. In TEST environment, or if a merchant isn't recognized, a “Pay Unverified Merchant” message is displayed in the payment sheet.
+	GoogleExistingMethodRequired   bool                        `json:"googleExistingMethodRequired"`   // (existingPaymentMethodRequired) If set to true then the IsReadyToPayResponse object includes an additional property that describes the visitor's readiness to pay with one or more payment methods specified in allowedPaymentMethods. (https://developers.google.com/pay/api/web/reference/request-objects#IsReadyToPayRequest)
+	GoogleEmailReq                 bool                        `json:"googleEmailReq"`                 // (emailRequired) Set to true to request an email address. (https://developers.google.com/pay/api/web/reference/request-objects#PaymentDataRequest)
+	GoogleAcceptCard               bool                        `json:"googleAcceptCard"`               // (Card {type = "CARD"}) Enable this to allow card payments through GooglePay
+	GoogleCardAuthMethods          []GoogleCardAuthMethod      `json:"googleCardAuthMethods"`          // (Card {parameters.allowedAuthMethods}) Fields supported to authenticate a card transaction.
+	GoogleCardNetworks             []GoogleCardNetwork         `json:"googleCardNetworks"`             // (Card {parameters.allowedCardNetworks}) One or more card networks that you support, also supported by the Google Pay API.
+	GoogleCardAllowPrepaid         bool                        `json:"googleCardAllowPrepaid"`         // (Card {parameters.allowPrepaidCards}) Allow customer to pay with prepaid card
+	GoogleCardAllowCredit          bool                        `json:"googleCardAllowCredit"`          // (Card {parameters.allowCreditCards}) Allow customer to pay with credit card
+	GoogleCardBillingAddressReq    bool                        `json:"googleCardBillingAddressReq"`    // (Card {parameters.billingAddressRequired}) Set to true if you require a billing address. A billing address should only be requested if it's required to process the transaction
+	GoogleCardBillingAddressFormat GoogleCardBillingAddressReq `json:"googleCardBillingAddressFormat"` // (Card {parameters.billingAddressParameters.format) Billing address format required to complete the transaction.
+	GoogleCardBillingPhoneReq      bool                        `json:"googleCardBillingPhoneReq"`      // (Card {parameters.billingAddressParameters.phoneNumberRequired) Set to true if a phone number is required to process the transaction.
+	GoogleCardTokenType            GoogleTokenType             `json:"googleCardTokenType"`            // (Card {tokenizationSpecification.type})
+	GoogleCardGateway              GoogleCardGateway           `json:"googleCardGateway"`              // (Card {tokenizationSpecification.parameters.gateway}) https://developers.google.com/pay/api/web/reference/request-objects#gateway
+	GoogleCardMerchantId           string                      `json:"googleCardMerchantId"`           // (Card {tokenizationSpecification.parameters.gatewayMerchantId}) https://developers.google.com/pay/api/web/reference/request-objects#gateway
 }
 
 type (
 	GoogleEnvironment           string
 	GoogleCardGateway           string
 	GoogleCardAuthMethod        string
-	GoogleCardTokenType         string
+	GoogleTokenType             string
 	GoogleCardNetwork           string
 	GoogleCardBillingAddressReq string
 )
 
 const (
-	GoogleCardBillingAddressReqNONE GoogleCardBillingAddressReq = ""
 	GoogleCardBillingAddressReqMIN  GoogleCardBillingAddressReq = "MIN"  // Name, country code, and postal code (default).
 	GoogleCardBillingAddressReqFULL GoogleCardBillingAddressReq = "FULL" // Name, street address, locality, region, country code, and postal code.
 
@@ -39,11 +38,11 @@ const (
 	GoogleCardGatewayWORLDPAY GoogleCardGateway = "worldpay"
 	GoogleCardGatewayPAYSAFE  GoogleCardGateway = "paysafe"
 
-	GoogleCardTokenTypeDIRECT  GoogleCardTokenType = "DIRECT"
-	GoogleCardTokenTypeGATEWAY GoogleCardTokenType = "PAYMENT_GATEWAY"
+	GoogleCardTokenTypeDIRECT  GoogleTokenType = "DIRECT"
+	GoogleCardTokenTypeGATEWAY GoogleTokenType = "PAYMENT_GATEWAY"
 
-	GoogleCardAuthMethodPAN GoogleCardAuthMethod = "PAN_ONLY"
-	GoogleCardAuthMethod3DS GoogleCardAuthMethod = "CRYPTOGRAM_3DS"
+	GoogleCardAuthMethodPAN GoogleCardAuthMethod = "PAN_ONLY"       // This authentication method is associated with payment cards stored on file with the user's Google Account. Returned payment data includes personal account number (PAN) with the expiration month and the expiration year.
+	GoogleCardAuthMethod3DS GoogleCardAuthMethod = "CRYPTOGRAM_3DS" // This authentication method is associated with cards stored as Android device tokens. Returned payment data includes a 3-D Secure (3DS) cryptogram generated on the device.
 
 	GoogleCardNetworkAMEX       GoogleCardNetwork = "AMEX"
 	GoogleCardNetworkDISCOVER   GoogleCardNetwork = "DISCOVER"

--- a/connectorconfig/google.go
+++ b/connectorconfig/google.go
@@ -37,6 +37,7 @@ const (
 
 	GoogleCardGatewayWORLDPAY GoogleCardGateway = "worldpay"
 	GoogleCardGatewayPAYSAFE  GoogleCardGateway = "paysafe"
+	GoogleCardGatewayVANTIV   GoogleCardGateway = "vantiv"
 
 	GoogleCardTokenTypeDIRECT  GoogleTokenType = "DIRECT"
 	GoogleCardTokenTypeGATEWAY GoogleTokenType = "PAYMENT_GATEWAY"

--- a/connectorconfig/worldpay.go
+++ b/connectorconfig/worldpay.go
@@ -27,6 +27,7 @@ type WorldpayCredentials struct {
 	CardinalApiIdentifier *string             `json:"cardinalApiIdentifier" yaml:"cardinalApiIdentifier" validate:"required"`
 	CardinalApiKey        *string             `json:"cardinalApiKey" yaml:"cardinalApiKey" validate:"required"`
 	CardinalOrgUnitId     *string             `json:"cardinalOrgUnitId" yaml:"cardinalOrgUnitId" validate:"required"`
+	GooglePayPageId       string              `json:"googlePayPageId"` // vantiv:merchantPayPageId
 	GooglePay
 	ApplePay
 }

--- a/utils/generate.go
+++ b/utils/generate.go
@@ -200,7 +200,20 @@ func buildSpec(conf Template) (object.Specification, error) {
 				AppleMerchantCertificate: &chg,
 				AppleMerchantPrivateKey:  &chg,
 			},
+			GooglePayPageId: chg,
+			GooglePay: connectorconfig.GooglePay{
+				GoogleEnvironment:              connectorconfig.GoogleEnvironmentTEST,
+				GoogleMerchantId:               chg,
+				GoogleMerchantName:             chg,
+				GoogleCardAuthMethods:          []connectorconfig.GoogleCardAuthMethod{connectorconfig.GoogleCardAuthMethodPAN, connectorconfig.GoogleCardAuthMethod3DS},
+				GoogleCardNetworks:             []connectorconfig.GoogleCardNetwork{connectorconfig.GoogleCardNetworkAMEX, connectorconfig.GoogleCardNetworkDISCOVER, connectorconfig.GoogleCardNetworkINTERAC, connectorconfig.GoogleCardNetworkJCB, connectorconfig.GoogleCardNetworkMASTERCARD, connectorconfig.GoogleCardNetworkVISA},
+				GoogleCardBillingAddressFormat: connectorconfig.GoogleCardBillingAddressReqMIN,
+				GoogleCardTokenType:            connectorconfig.GoogleCardTokenTypeGATEWAY,
+				GoogleCardGateway:              connectorconfig.GoogleCardGatewayVANTIV,
+				GoogleCardMerchantId:           chg,
+			},
 		})
+
 		return connector.Connector{Library: string(connectorconfig.LibraryWorldpay), Configuration: j}, nil
 	case confConnectorPool:
 		return connector.Pool{Restriction: "unrestricted", Connectors: []connector.PoolItem{{ConnectorID: chg}}}, nil


### PR DESCRIPTION
Removed static fields like API version and number
Added comments to fields to show nesting and structure
Moved fields around so that like components are contiguous
Moved PayPageID from google struct into worldpay as its vendor specific