### PR TITLE
Deprecate Connector.EnablePCIB

### DIFF
--- a/utils/validate_test.go
+++ b/utils/validate_test.go
@@ -19,6 +19,19 @@ func TestChargeLabelVariables(t *testing.T) {
 	assert.Equal(t, errs, map[string]string{})
 }
 
+// TestDeprecatedEnablePCIBStillValidates guards the reason Connector.EnablePCIB is
+// still declared. Nothing reads it any more, but Validate decodes with
+// DisallowUnknownFields, so deleting the field would fail `chive validate` and
+// `chive apply` for every stored config that still sets it. If this starts
+// reporting `json: unknown field "enablePCIB"`, the field was removed before those
+// configs were cleaned up.
+func TestDeprecatedEnablePCIBStillValidates(t *testing.T) {
+	rawJson := []byte(`{"kind":"Connector","metadata":{"projectId":"change-me","name":"change-me","displayName":"","description":"","annotations":null,"labels":null,"disabled":false},"specVersion":"v1","selector":{"priority":50,"expressions":[]},"spec":{"library":"paysafe","enablePCIB":true,"configuration":"eyJtZXJjaGFudFVybCI6ImNoYW5nZS1tZSIsImFjcXVpcmVyIjoiY2hhbmdlLW1lIiwiYWNjb3VudElEIjoiY2hhbmdlLW1lIiwiYXBpVXNlcm5hbWUiOiJjaGFuZ2UtbWUiLCJhcGlQYXNzd29yZCI6ImNoYW5nZS1tZSIsImVudmlyb25tZW50IjoiTU9DSyIsImNvdW50cnkiOiIiLCJjdXJyZW5jeSI6IlVTRCIsInVzZVZhdWx0IjpmYWxzZSwic2luZ2xlVXNlVG9rZW5QYXNzd29yZCI6IiIsInNpbmdsZVVzZVRva2VuVXNlcm5hbWUiOiIifQ=="}}`)
+	configuration.Initialise()
+	errs := Validate(rawJson, "v1")
+	assert.Equal(t, errs, map[string]string{})
+}
+
 // test for additional unknown fields
 func TestAdditionalUnknownFields(t *testing.T) {
 	rawJson := []byte(`{"Kind":"Connector","metadata":{"projectId":"change-me","bob":"cat","Name":"change-me","uuid":"","displayName":"","description":"","annotations":null,"labels":null,"disabled":true},"specVersion":"v1","selector":{"priority":50,"expressions":[{"key":"charge.amount.currency","operator":"Equal","conversion":"","values":["GBP"]}]},"spec":{"library":"paypal-websitepaymentspro","configuration":"eyJhcGlVc2VybmFtZSI6IkNIQU5HRS1NRSIsImFwaVBhc3N3b3JkIjoiQ0hBTkdFLU1FIiwiYXBpU2lnbmF0dXJlIjoiQ0hBTkdFLU1FIiwic3VwcG9ydGVkQ3VycmVuY2llcyI6WyJVU0QiXSwiY2FyZGluYWxQcm9jZXNzb3JJRCI6bnVsbCwiY2FyZGluYWxNZXJjaGFudElEIjpudWxsLCJjYXJkaW5hbFRyYW5zYWN0aW9uUHciOm51bGwsImNhcmRpbmFsVHJhbnNhY3Rpb25VUkwiOm51bGwsImNhcmRpbmFsQVBJSWRlbnRpZmllciI6bnVsbCwiY2FyZGluYWxBUElLZXkiOm51bGwsImNhcmRpbmFsT3JnVW5pdElEIjpudWxsLCJlbnZpcm9ubWVudCI6InNhbmRib3gifQ=="}}`)

--- a/v1/connector/connector.go
+++ b/v1/connector/connector.go
@@ -30,8 +30,22 @@ type Connector struct {
 	Configuration   []byte          `json:"configuration,omitempty" yaml:"configuration,omitempty" validate:"required_without=ConfigurationID"`
 	ConfigID        string          `json:"configId,omitempty" yaml:"configId,omitempty"`
 	ConfigAuth      string          `json:"configAuth,omitempty" yaml:"configAuth,omitempty"`
-	EnablePCIB      bool            `json:"enablePCIB,omitempty" yaml:"enablePCIB,omitempty"`
-	SCAConnectorID  string          `json:"scaConnectorID,omitempty" yaml:"scaConnectorID,omitempty"`
+
+	// Deprecated: EnablePCIB is ignored. PCIB is always enabled - the gate this flag
+	// controlled diverted connectors into the retired processing vault, and every
+	// reader was removed in chargehive-assemble#1715.
+	//
+	// It could not be honoured even in principle: the field is a bool tagged
+	// omitempty, so "unset" and "explicitly false" serialise identically and there is
+	// no opt-out to preserve.
+	//
+	// The declaration is retained only so configs that still carry enablePCIB keep
+	// validating - utils.Validate decodes with DisallowUnknownFields, so deleting it
+	// would fail `chive validate` and `chive apply` on those files. Do not read this
+	// field; delete it once stored configs no longer set it.
+	EnablePCIB bool `json:"enablePCIB,omitempty" yaml:"enablePCIB,omitempty"`
+
+	SCAConnectorID string `json:"scaConnectorID,omitempty" yaml:"scaConnectorID,omitempty"`
 }
 
 // GetKind returns the Connector kind


### PR DESCRIPTION
## Why

The gate `EnablePCIB` controlled diverted connectors into the retired processing vault. [chargehive-assemble#1715](https://github.com/lucidcube/chargehive-assemble/pull/1715) removed every reader, so the field is now inert — but nothing in the type said so, leaving it easy for someone to reasonably reintroduce a gate on it.

It could not be honoured even in principle: it's a `bool` tagged `omitempty`, so "unset" and "explicitly false" serialise identically. There is no merchant opt-out to preserve, which is also why inverting it to `disablePCIB` was never an option.

## Why deprecate rather than delete

`utils.Validate` decodes via `object.FromJsonStrict` → `DisallowUnknownFields`, and both `chive validate` and `chive apply` (`chargehive-cli/cmd/validate.go:68`, `cmd/apply.go:85`) go through it. Deleting the declaration would fail every stored config that still carries the key:

```
json: unknown field "enablePCIB"
```

Dev alone has 147 connectors. The field can be deleted once stored configs are known clean — the doc comment says so explicitly.

## Changes

- `// Deprecated:` marker on the field recording that it is ignored, why it cannot be honoured, and why the declaration stays.
- `TestDeprecatedEnablePCIBStillValidates` — asserts a Connector config carrying `enablePCIB` still validates cleanly.

## Test plan

- `go build ./...` — clean.
- `go test ./...` — **entire suite passes, no failures.**
- New test passes, and **verified it actually guards**: retagging the field to simulate its removal makes it fail with `map[json:json: unknown field "enablePCIB"] does not equal map[]` — precisely the breakage this PR exists to prevent. Restored and re-run green.
- `go vet ./...` reports two findings, both pre-existing in untouched files (`v1/policy/method_verify.go:26` struct tag spacing, `utils/generate.go:396` unkeyed fields).

## Follow-up

Deleting the field needs a sweep of stored configs first — `chargehive_object.active_objects` where `kind='Connector'` and the spec still contains `enablePCIB`. Not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)